### PR TITLE
Google safe browsing integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Provides functionality for the api, investigates a potentially malicious website
 ## Usage
 
 - Check `node -v` to make sure you're running `node` at least 12.0. Node 13 is preferred.
+- Run `cp config/config.template.json config/config.json` and fill in your API key for Google Safe Browsing in `config/config.json`.
 - Run `npm install` to set up puppeteer.
 - Use `npm start` to run the program.
 - Place files into the `input` directory, based on the syntax of `request.json`.

--- a/config/config.template.json
+++ b/config/config.template.json
@@ -1,0 +1,3 @@
+{
+  "google_safe_browsing_api_key": ""
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1266,6 +1266,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "nodemon": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@limedocs/express-middleware-memfs": "^1.0.0-beta.18",
     "express": "^4.17.1",
     "memfs": "^3.0.4",
+    "node-fetch": "^2.6.0",
     "puppeteer": "^1.20.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import fs from 'fs';
 
 // Routes
 import ticketRouter from './routes/ticket.js';
@@ -15,6 +16,17 @@ app.use(express.urlencoded({ extended: true }));
 // Use routes
 app.use('/ticket', ticketRouter);
 app.use('/artifacts', artifactRouter);
+
+let config;
+export { config };
+try {
+  console.log('Reading config file.');
+  let data = fs.readFileSync('./config/config.json');
+  config = JSON.parse(data);
+} catch (err) {
+  console.log(`Error when reading config file: ${err.message}. Exit now.`);
+  process.exit();
+}
 
 // Serve app
 app.listen(port, () =>

--- a/src/manager/ResourceManager.js
+++ b/src/manager/ResourceManager.js
@@ -1,7 +1,4 @@
 import path from 'path';
-import { config } from '../index.js';
-
-import fetch from 'node-fetch';
 
 export default class ResourceManager {
   constructor() {
@@ -20,45 +17,6 @@ export default class ResourceManager {
 
       // use hostname/filename as identifier:
       const processedURL = new URL(url);
-
-      const safeBrowsingURL =
-        'https://safebrowsing.googleapis.com/v4/threatMatches:find?key=' +
-        index.config.google_safe_browsing_api_key;
-      const request = {
-        client: {
-          clientId: '4950',
-          clientVersion: '0.0.1',
-        },
-        threatInfo: {
-          threatTypes: ['MALWARE'],
-          platformTypes: ['ANY_PLATFORM'],
-          threatEntryTypes: ['URL'],
-          threatEntries: [{ url: processedURL }],
-        },
-      };
-
-      try {
-        fetch(safeBrowsingURL, {
-          method: 'POST',
-          body: JSON.stringify(request),
-          responseType: 'application/json',
-        })
-          .then(res => res.json())
-          .then(res => {
-            if (res.matches === undefined) {
-              // console.log('----------------------------------------------');
-              // console.log('no malware find');
-            } else {
-              const { matches } = res.matches;
-              const match = matches[0];
-              console.log('----------------------------------------------');
-              console.log('malware find:');
-              console.log(match);
-            }
-          });
-      } catch (error) {
-        console.log(error);
-      }
 
       const hostname = processedURL.hostname;
       // grab the filename from the path specifier:

--- a/src/manager/ResourceManager.js
+++ b/src/manager/ResourceManager.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import { config } from '../index.js';
 
 export default class ResourceManager {
   constructor() {
@@ -19,7 +20,8 @@ export default class ResourceManager {
       const processedURL = new URL(url);
 
       const safeBrowsingURL =
-        'https://safebrowsing.googleapis.com/v4/threatMatches:find?key=' + '';
+        'https://safebrowsing.googleapis.com/v4/threatMatches:find?key=' +
+        index.config.google_safe_browsing_api_key;
       const request = {
         client: {
           clientId: '4950',

--- a/src/manager/ResourceManager.js
+++ b/src/manager/ResourceManager.js
@@ -3,6 +3,7 @@ import path from 'path';
 export default class ResourceManager {
   constructor() {
     this.resources = [];
+    this.urls = [];
   }
 
   setupResourceCollection(page, ticket) {
@@ -15,6 +16,10 @@ export default class ResourceManager {
       const status = response.status();
       const ok = response.ok();
 
+      if (ok) {
+        this.urls.push(url);
+      }
+
       // use hostname/filename as identifier:
       const processedURL = new URL(url);
 
@@ -24,6 +29,7 @@ export default class ResourceManager {
         processedURL.pathname.lastIndexOf('/') + 1
       );
       let identifier = `${hostname}/${filename}`;
+      console.log(identifier);
 
       // handle 2 objects with same identifier:
       const pathParsed = path.parse(filename);
@@ -49,5 +55,9 @@ export default class ResourceManager {
 
   process() {
     return this.resources;
+  }
+
+  getURLs() {
+    return this.urls;
   }
 }

--- a/src/manager/ResourceManager.js
+++ b/src/manager/ResourceManager.js
@@ -1,6 +1,8 @@
 import path from 'path';
 import { config } from '../index.js';
 
+import fetch from 'node-fetch';
+
 export default class ResourceManager {
   constructor() {
     this.resources = [];
@@ -34,8 +36,6 @@ export default class ResourceManager {
           threatEntries: [{ url: processedURL }],
         },
       };
-
-      const fetch = require('node-fetch');
 
       try {
         fetch(safeBrowsingURL, {

--- a/src/manager/ResourceManager.js
+++ b/src/manager/ResourceManager.js
@@ -17,6 +17,47 @@ export default class ResourceManager {
 
       // use hostname/filename as identifier:
       const processedURL = new URL(url);
+
+      const safeBrowsingURL =
+        'https://safebrowsing.googleapis.com/v4/threatMatches:find?key=' + '';
+      const request = {
+        client: {
+          clientId: '4950',
+          clientVersion: '0.0.1',
+        },
+        threatInfo: {
+          threatTypes: ['MALWARE'],
+          platformTypes: ['ANY_PLATFORM'],
+          threatEntryTypes: ['URL'],
+          threatEntries: [{ url: processedURL }],
+        },
+      };
+
+      const fetch = require('node-fetch');
+
+      try {
+        fetch(safeBrowsingURL, {
+          method: 'POST',
+          body: JSON.stringify(request),
+          responseType: 'application/json',
+        })
+          .then(res => res.json())
+          .then(res => {
+            if (res.matches === undefined) {
+              // console.log('----------------------------------------------');
+              // console.log('no malware find');
+            } else {
+              const { matches } = res.matches;
+              const match = matches[0];
+              console.log('----------------------------------------------');
+              console.log('malware find:');
+              console.log(match);
+            }
+          });
+      } catch (error) {
+        console.log(error);
+      }
+
       const hostname = processedURL.hostname;
       // grab the filename from the path specifier:
       const filename = processedURL.pathname.substring(

--- a/src/middleware/wrap.js
+++ b/src/middleware/wrap.js
@@ -1,0 +1,6 @@
+// middleware/wrap.js
+export const wrap = fn => {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+};

--- a/src/middleware/wrap.js
+++ b/src/middleware/wrap.js
@@ -1,6 +1,0 @@
-// middleware/wrap.js
-export const wrap = fn => {
-  return (req, res, next) => {
-    Promise.resolve(fn(req, res, next)).catch(next);
-  };
-};

--- a/src/routes/ticket.js
+++ b/src/routes/ticket.js
@@ -19,13 +19,13 @@ router.post('/', async (req, res) => {
     );
 
     const ticket = new Ticket(ID, url, screenshots);
-    const artifacts = await ticketManager.processTicket(ticket);
+    const results = await ticketManager.processTicket(ticket);
 
     console.log(
       `Finished processing ticket with ID ${ticket.getID()}! Awaiting more...`
     );
 
-    res.json(artifacts);
+    res.json(results);
   } catch (e) {
     console.error('An error occurred when processing this ticket.');
     console.log(e);

--- a/src/utils/tickets.js
+++ b/src/utils/tickets.js
@@ -88,7 +88,7 @@ const processTicket = async ticket => {
   return {
     success: true,
     fileArtifacts: artifacts.map(ArtifactManager.artifactToPath),
-    malwareMatches: await malwareMatches,
+    malwareMatches: JSON.stringify(await malwareMatches),
   };
 };
 

--- a/src/utils/tickets.js
+++ b/src/utils/tickets.js
@@ -11,6 +11,7 @@ const getMalwareMatches = async URL => {
   const safeBrowsingURL =
     'https://safebrowsing.googleapis.com/v4/threatMatches:find?key=' +
     config.google_safe_browsing_api_key;
+  console.log(requestURLList);
   const request = {
     client: {
       clientId: '4950',
@@ -20,7 +21,7 @@ const getMalwareMatches = async URL => {
       threatTypes: ['MALWARE'],
       platformTypes: ['ANY_PLATFORM'],
       threatEntryTypes: ['URL'],
-      threatEntries: [{ url: URL }],
+      threatEntries: requestURLList,
     },
   };
 
@@ -55,9 +56,6 @@ const processTicket = async ticket => {
   console.log(`Starting to process ticket #${ticketId}.`);
   console.log(`URL: ${ticketURL}`);
 
-  // Get result from Google Safe Browsing API v4
-  const malwareMatches = getMalwareMatches(ticketURL);
-
   const resourceManager = new ResourceManager();
 
   // Setup browser
@@ -86,11 +84,14 @@ const processTicket = async ticket => {
 
   await page.close();
 
+  // Get result from Google Safe Browsing API v4
+  const malwareMatches = getMalwareMatches(await resourceManager.getURLs());
+
   // Success, return list of paths
   return {
     success: true,
     fileArtifacts: artifacts.map(ArtifactManager.artifactToPath),
-    malwareMatches: JSON.stringify(await malwareMatches),
+    malwareMatches: JSON.stringify(malwareMatches),
   };
 };
 

--- a/src/utils/tickets.js
+++ b/src/utils/tickets.js
@@ -6,7 +6,7 @@ import { config } from '../index.js';
 
 import fetch from 'node-fetch';
 
-const getSafeBrowsingIndex = async URL => {
+const getMalwareMatches = async URL => {
   console.log(`Getting Google Safe Browsing information...`);
   const safeBrowsingURL =
     'https://safebrowsing.googleapis.com/v4/threatMatches:find?key=' +
@@ -24,26 +24,28 @@ const getSafeBrowsingIndex = async URL => {
     },
   };
 
-  try {
-    const res = await fetch(safeBrowsingURL, {
-      method: 'POST',
-      body: JSON.stringify(request),
-      responseType: 'application/json',
+  return fetch(safeBrowsingURL, {
+    method: 'POST',
+    body: JSON.stringify(request),
+    responseType: 'application/json',
+  })
+    .then(res => {
+      return res.json();
+    })
+    .then(json => {
+      if (json.matches === undefined) {
+        console.log('No malware found');
+        return [];
+      } else {
+        console.log('Malware found');
+        console.log(json.matches);
+        return json.matches;
+      }
+    })
+    .catch(error => {
+      console.log(error);
+      return [];
     });
-    const json = await res.json();
-    if (json.matches === undefined) {
-      console.log('No malware found');
-      return null;
-    } else {
-      const match = json.matches[0];
-      console.log('Malware found:');
-      console.log(match);
-      return match;
-    }
-  } catch (error) {
-    console.log(error);
-    return null;
-  }
 };
 
 const processTicket = async ticket => {
@@ -54,7 +56,7 @@ const processTicket = async ticket => {
   console.log(`URL: ${ticketURL}`);
 
   // Get result from Google Safe Browsing API v4
-  const malwareMatches = getSafeBrowsingIndex(ticketURL);
+  const malwareMatches = getMalwareMatches(ticketURL);
 
   const resourceManager = new ResourceManager();
 

--- a/src/utils/tickets.js
+++ b/src/utils/tickets.js
@@ -2,15 +2,61 @@ import ScreenshotManager from './screenshots.js';
 import ResourceManager from '../manager/ResourceManager.js';
 import getBrowser from '../utils/browser.js';
 import ArtifactManager from '../manager/ArtifactManager.js';
+import { config } from '../index.js';
+
+import fetch from 'node-fetch';
+
+const getSafeBrowsingIndex = async URL => {
+  console.log(`Getting Google Safe Browsing information...`);
+  const safeBrowsingURL =
+    'https://safebrowsing.googleapis.com/v4/threatMatches:find?key=' +
+    config.google_safe_browsing_api_key;
+  const request = {
+    client: {
+      clientId: '4950',
+      clientVersion: '0.0.1',
+    },
+    threatInfo: {
+      threatTypes: ['MALWARE'],
+      platformTypes: ['ANY_PLATFORM'],
+      threatEntryTypes: ['URL'],
+      threatEntries: [{ url: URL }],
+    },
+  };
+
+  try {
+    const res = await fetch(safeBrowsingURL, {
+      method: 'POST',
+      body: JSON.stringify(request),
+      responseType: 'application/json',
+    });
+    const json = await res.json();
+    if (json.matches === undefined) {
+      console.log('No malware found');
+      return null;
+    } else {
+      const match = json.matches[0];
+      console.log('Malware found:');
+      console.log(match);
+      return match;
+    }
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+};
 
 const processTicket = async ticket => {
   const ticketId = ticket.getID();
   const ticketURL = ticket.getURL();
 
-  const resourceManager = new ResourceManager();
-
   console.log(`Starting to process ticket #${ticketId}.`);
   console.log(`URL: ${ticketURL}`);
+
+  // Get result from Google Safe Browsing API v4
+  const malwareMatches = getSafeBrowsingIndex(ticketURL);
+
+  const resourceManager = new ResourceManager();
 
   // Setup browser
   const browser = await getBrowser();
@@ -42,6 +88,7 @@ const processTicket = async ticket => {
   return {
     success: true,
     fileArtifacts: artifacts.map(ArtifactManager.artifactToPath),
+    malwareMatches: await malwareMatches,
   };
 };
 


### PR DESCRIPTION
Google safe browsing API needs an API key, edit `config.json` under `config` folder. `config/config.json` is ignored, do not try to add this file.

```diff
- const artifacts = await ticketManager.processTicket(ticket);
+ const results = await ticketManager.processTicket(ticket);
```
I put the result from Google in the return value of `TicketManager.processTicket()`, and it's not a file artifact, so I change the variable name for that. And we might need to add more information about the ticket in the result in the future, so I think this change should be OK.

See also https://github.com/csci4950tgt/api/pull/59, [frontend changes](https://github.com/csci4950tgt/frontend/tree/display-google-safe-browsing-information)
Fix #23.

Other things to consider:
- The API can detect multiple URLs in 1 request, maybe we can extract all the links in a webpage (from puppeteer?) and send them to the API.
- Discuss the flags we need ([Google's API documentation](https://developers.google.com/safe-browsing/v4/reference/rest/v4/ThreatInfo). [Platforms](https://developers.google.com/safe-browsing/v4/reference/rest/v4/PlatformType)? [Threat types](https://developers.google.com/safe-browsing/v4/reference/rest/v4/ThreatType)?)
- The link above also can be referenced by the frontend.