### PR TITLE
OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,13 @@ Provides functionality for the api, investigates a potentially malicious website
 
 - Grabs screenshots of the target URL, with customizable browser viewport (width/height)
 - Accepts a User-Agent string to pass to the website
-
-### Upcoming
-
-- Beautified JS: Web service will include a JS package to beautify JS string
+- Does OCR on site screenshots
+- Checks retrieved resources against Google safe browsing database
 
 ## Usage
 
 - Check `node -v` to make sure you're running `node` at least 12.0. Node 13 is preferred.
 - Run `cp config/config.template.json config/config.json` and fill in your API key for Google Safe Browsing in `config/config.json`.
-- Run `npm install` to set up puppeteer.
+- Run `npm install` to set up dependencies.
+- On macOS, use `brew install yara` and `brew install tesseract` to set up native dependencies. On other platforms, use corresponding versions from your system's package manager.
 - Use `npm start` to run the program.
-- Place files into the `input` directory, based on the syntax of `request.json`.
-- Look in the `output/` directory, the filename of the input will match to the output

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,11 +159,6 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
-    "bmp-js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-      "integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM="
-    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -274,6 +269,11 @@
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
       "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
       "dev": true
+    },
+    "cer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cer/-/cer-1.0.0.tgz",
+      "integrity": "sha1-E/XCGjImTNF/64IjlRexm4hjY3U="
     },
     "chalk": {
       "version": "2.4.2",
@@ -658,11 +658,6 @@
         "pend": "~1.2.0"
       }
     },
-    "file-type": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
-      "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg=="
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -929,11 +924,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "idb-keyval": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-3.2.0.tgz",
-      "integrity": "sha512-slx8Q6oywCCSfKgPgL0sEsXtPVnSbTLWpyiDcu6msHOyKOLari1TD1qocXVCft80umnkk3/Qqh3lwoFt8T/BPQ=="
-    },
     "ignore": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
@@ -1031,11 +1021,6 @@
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
-    "is-electron": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
-      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
-    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1112,11 +1097,6 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
-    "is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1125,8 +1105,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1394,7 +1373,8 @@
     "opencollective-postinstall": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
@@ -1832,11 +1812,6 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
-    "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -2112,28 +2087,16 @@
         }
       }
     },
-    "tesseract.js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-2.0.2.tgz",
-      "integrity": "sha512-LeZmvmYDDErqBbVSzvGHAujZUQSmjYB0iZkmwvbc+QbA840rf+0CYkCMURIuE54zDrv0Qms+QINZokQr78FkBA==",
+    "tesseractocr": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/tesseractocr/-/tesseractocr-1.2.1.tgz",
+      "integrity": "sha512-m9jNyL9Bsy52FJpt8+wXBO3JkA0xQrBLlZMw7yUQ0k9uBKh+k3Wv4Wi3VDNUM45qLKEO93uwLEa0x1Mo+zSZjA==",
       "requires": {
-        "bmp-js": "^0.1.0",
-        "file-type": "^12.4.1",
-        "idb-keyval": "^3.2.0",
-        "is-electron": "^2.2.0",
-        "is-url": "^1.2.4",
-        "node-fetch": "^2.6.0",
-        "opencollective-postinstall": "^2.0.2",
-        "regenerator-runtime": "^0.13.3",
-        "resolve-url": "^0.2.1",
-        "tesseract.js-core": "^2.0.0",
-        "zlibjs": "^0.3.1"
+        "cer": "^1.0.0",
+        "destroy": "^1.0.4",
+        "once": "^1.4.0",
+        "which": "^1.3.1"
       }
-    },
-    "tesseract.js-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-2.0.0.tgz",
-      "integrity": "sha512-Oi+V/0iuDQarM9OaLRso6y8U0lPZy9dDaLBoSWNd9c5FSsvgL6OoIDRS+Pum/noAQw7Q3V8vetlf+SgQNRdorA=="
     },
     "timed-out": {
       "version": "4.0.1",
@@ -2286,7 +2249,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -2351,11 +2313,6 @@
       "requires": {
         "fd-slicer": "~1.0.1"
       }
-    },
-    "zlibjs": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
-      "integrity": "sha1-UBl+2yihxCymWcyLTmqd3W1ERVQ="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,11 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM="
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -653,6 +658,11 @@
         "pend": "~1.2.0"
       }
     },
+    "file-type": {
+      "version": "12.4.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
+      "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -919,6 +929,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "idb-keyval": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-3.2.0.tgz",
+      "integrity": "sha512-slx8Q6oywCCSfKgPgL0sEsXtPVnSbTLWpyiDcu6msHOyKOLari1TD1qocXVCft80umnkk3/Qqh3lwoFt8T/BPQ=="
+    },
     "ignore": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
@@ -1016,6 +1031,11 @@
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
+    "is-electron": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1091,6 +1111,11 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -1369,8 +1394,7 @@
     "opencollective-postinstall": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
-      "dev": true
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -1808,6 +1832,11 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -2083,6 +2112,29 @@
         }
       }
     },
+    "tesseract.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-2.0.2.tgz",
+      "integrity": "sha512-LeZmvmYDDErqBbVSzvGHAujZUQSmjYB0iZkmwvbc+QbA840rf+0CYkCMURIuE54zDrv0Qms+QINZokQr78FkBA==",
+      "requires": {
+        "bmp-js": "^0.1.0",
+        "file-type": "^12.4.1",
+        "idb-keyval": "^3.2.0",
+        "is-electron": "^2.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.0",
+        "opencollective-postinstall": "^2.0.2",
+        "regenerator-runtime": "^0.13.3",
+        "resolve-url": "^0.2.1",
+        "tesseract.js-core": "^2.0.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "tesseract.js-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-2.0.0.tgz",
+      "integrity": "sha512-Oi+V/0iuDQarM9OaLRso6y8U0lPZy9dDaLBoSWNd9c5FSsvgL6OoIDRS+Pum/noAQw7Q3V8vetlf+SgQNRdorA=="
+    },
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
@@ -2299,6 +2351,11 @@
       "requires": {
         "fd-slicer": "~1.0.1"
       }
+    },
+    "zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha1-UBl+2yihxCymWcyLTmqd3W1ERVQ="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "express": "^4.17.1",
     "memfs": "^3.0.4",
     "puppeteer": "^1.20.0",
+    "tesseractocr": "^1.2.1",
     "yara": "^2.2.0",
-    "node-fetch": "^2.6.0",
-    "tesseract.js": "^2.0.2"
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "husky": "^3.0.9",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "memfs": "^3.0.4",
     "puppeteer": "^1.20.0",
     "yara": "^2.2.0",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "tesseract.js": "^2.0.2"
   },
   "devDependencies": {
     "husky": "^3.0.9",

--- a/src/manager/OCRManager.js
+++ b/src/manager/OCRManager.js
@@ -2,30 +2,28 @@ import Tesseract from 'tesseract.js';
 
 export default class OCRManager {
   constructor(lang = 'eng') {
-    this._lang = lang;
-    // const { createWorker } = require('tesseract.js');
-    this._worker = Tesseract.createWorker();
+    this.lang = lang;
+    this.worker = Tesseract.createWorker();
   }
 
-  getTextFromImage = async (lang = this._lang, screenShot) => {
-    await this._worker.load();
-    await this._worker.loadLanguage(lang);
-    await this._worker.initialize(lang);
+  async getTextFromImage(lang = this.lang, screenShot) {
+    await this.worker.load();
+    await this.worker.loadLanguage(lang);
+    await this.worker.initialize(lang);
+
     const {
       data: { text },
-    } = await this._worker.recognize(screenShot);
-    await this._worker.terminate();
-    console.log('Here.');
-    console.log(text);
-    return text;
-  };
+    } = await this.worker.recognize(screenShot);
 
-  processImages(lang = this._lang, screenShots) {
-    var textArtifacts = [];
-    var ss;
-    for (ss in screenShots) {
-      textArtifacts.push(this.getTextFromImage(lang, ss));
-    }
-    return textArtifacts;
+    await this.worker.terminate();
+
+    console.log(`Recognized the following text in image: ${text}`);
+    console.log(text);
+
+    return text;
+  }
+
+  processImages(lang = this.lang, screenshots) {
+    return screenshots.map(ss => this.getTextFromImage(lang, ss));
   }
 }

--- a/src/manager/OCRManager.js
+++ b/src/manager/OCRManager.js
@@ -1,29 +1,56 @@
 import Tesseract from 'tesseract.js';
+import EventEmitter from 'events';
+
+// notifier once initialized
+class OCRReadyEmitter extends EventEmitter {}
 
 export default class OCRManager {
   constructor(lang = 'eng') {
     this.lang = lang;
     this.worker = Tesseract.createWorker();
+    this.ready = false;
+    this.readyEmitter = new OCRReadyEmitter();
   }
 
-  async getTextFromImage(lang = this.lang, screenShot) {
+  async init() {
     await this.worker.load();
-    await this.worker.loadLanguage(lang);
-    await this.worker.initialize(lang);
+    await this.worker.loadLanguage(this.lang);
+    await this.worker.initialize(this.lang);
 
-    const {
-      data: { text },
-    } = await this.worker.recognize(screenShot);
-
-    await this.worker.terminate();
-
-    console.log(`Recognized the following text in image: ${text}`);
-    console.log(text);
-
-    return text;
+    this.ready = true;
+    this.readyEmitter.emit('ready');
   }
 
-  processImages(lang = this.lang, screenshots) {
-    return screenshots.map(ss => this.getTextFromImage(lang, ss));
+  // helper to avoid race condition on startup
+  waitUntilReady() {
+    return new Promise(resolve => {
+      if (this.ready) {
+        resolve(true);
+      } else {
+        this.readyEmitter.on('ready', resolve);
+      }
+    });
+  }
+
+  async getTextFromImage(screenshot) {
+    console.log(screenshot);
+
+    const res = await this.worker.recognize(screenshot.data);
+
+    console.log(res);
+
+    console.log(`Recognized the following text in image: ${res.data.text}`);
+
+    return res.data.text;
+  }
+
+  processImages(screenshots) {
+    // use Promise.all to wait for all screenshots to process
+    return Promise.all(screenshots.map(ss => this.getTextFromImage(ss)));
+  }
+
+  // Currently unused - shutdown OCR worker
+  shutdown() {
+    return this.worker.terminate();
   }
 }

--- a/src/manager/OCRManager.js
+++ b/src/manager/OCRManager.js
@@ -1,52 +1,26 @@
-import Tesseract from 'tesseract.js';
-import EventEmitter from 'events';
-
-// notifier once initialized
-class OCRReadyEmitter extends EventEmitter {}
+import recognize from 'tesseractocr';
+import path from 'path';
 
 export default class OCRManager {
   constructor(lang = 'eng') {
     this.lang = lang;
-    this.worker = Tesseract.createWorker({
-      logger: m => console.log(m),
-      errorHandler: m => console.error(m),
-    });
-    this.ready = false;
-    this.readyEmitter = new OCRReadyEmitter();
-  }
-
-  async init() {
-    await this.worker.load();
-    await this.worker.loadLanguage(this.lang);
-    await this.worker.initialize(this.lang);
-
-    this.ready = true;
-    this.readyEmitter.emit('ready');
-  }
-
-  // helper to avoid race condition on startup
-  waitUntilReady() {
-    return new Promise(resolve => {
-      if (this.ready) {
-        resolve(true);
-      } else {
-        this.readyEmitter.on('ready', resolve);
-      }
-    });
   }
 
   async getTextFromImage(screenshot) {
     console.log(`Start recognition process for ${screenshot.filename}.`);
 
-    const res = await this.worker.recognize(screenshot.data);
+    const res = await recognize(screenshot.data, { language: this.lang });
 
-    console.log(`Recognized the following text in image: ${res.data.text}`);
+    console.log(`Recognized the following text in image: ${res}`);
+
+    // don't include .png:
+    const baseScreenshotPath = path.parse(screenshot.filename).name;
 
     // assemble a file artifact-like object
     return {
       ticketId: screenshot.ticketId,
-      filename: `recognize-${screenshot.filename}.ocr`,
-      data: Buffer.from(res.data.text),
+      filename: `recognize-${baseScreenshotPath}.ocr`,
+      data: Buffer.from(res),
     };
   }
 
@@ -55,9 +29,7 @@ export default class OCRManager {
     // also does work in parallel
     return Promise.all(screenshots.map(ss => this.getTextFromImage(ss)));
   }
-
-  // Currently unused - shutdown OCR worker
-  shutdown() {
-    return this.worker.terminate();
-  }
 }
+
+// cleanup on premature exit:
+process.on('exit', () => recognize.cancelAll());

--- a/src/manager/OCRManager.js
+++ b/src/manager/OCRManager.js
@@ -1,8 +1,10 @@
+import Tesseract from 'tesseract.js';
+
 export default class OCRManager {
   constructor(lang = 'eng') {
     this._lang = lang;
-    const { createWorker } = require('tesseract.js');
-    this._worker = createWorker();
+    // const { createWorker } = require('tesseract.js');
+    this._worker = Tesseract.createWorker();
   }
 
   getTextFromImage = async (lang = this._lang, screenShot) => {
@@ -17,7 +19,8 @@ export default class OCRManager {
   };
 
   processImages(lang = this._lang, screenShots) {
-    const textArtifacts = [];
+    var textArtifacts = [];
+    var ss;
     for (ss in screenShots) {
       textArtifacts.push(this.getTextFromImage(lang, ss));
     }

--- a/src/manager/OCRManager.js
+++ b/src/manager/OCRManager.js
@@ -1,0 +1,26 @@
+export default class OCRManager {
+  constructor(lang = 'eng') {
+    this._lang = lang;
+    const { createWorker } = require('tesseract.js');
+    this._worker = createWorker();
+  }
+
+  getTextFromImage = async (lang = this._lang, screenShot) => {
+    await this._worker.load();
+    await this._worker.loadLanguage(lang);
+    await this._worker.initialize(lang);
+    const {
+      data: { text },
+    } = await this._worker.recognize(screenShot);
+    await this._worker.terminate();
+    return text;
+  };
+
+  processImages(lang = this._lang, screenShots) {
+    const textArtifacts = [];
+    for (ss in screenShots) {
+      textArtifacts.push(this.getTextFromImage(lang, ss));
+    }
+    return textArtifacts;
+  }
+}

--- a/src/manager/OCRManager.js
+++ b/src/manager/OCRManager.js
@@ -15,6 +15,8 @@ export default class OCRManager {
       data: { text },
     } = await this._worker.recognize(screenShot);
     await this._worker.terminate();
+    console.log('Here.');
+    console.log(text);
     return text;
   };
 

--- a/src/utils/tickets.js
+++ b/src/utils/tickets.js
@@ -81,8 +81,8 @@ const processTicket = async ticket => {
   const defaultUserAgent = await browser.userAgent();
   const ss = new ScreenshotManager(defaultUserAgent);
   const ssArtifacts = await ss.processScreenshots(ticket, page);
-  const ocr = new OCRManager();
-  const ocrArtifacts = await ocr.processImages('eng', ssArtifacts.data);
+  const ocrArtifacts = await ocrManager.processImages(ssArtifacts);
+
   artifacts.push(...ssArtifacts);
   artifacts.push(...ocrArtifacts);
 

--- a/src/utils/tickets.js
+++ b/src/utils/tickets.js
@@ -82,7 +82,7 @@ const processTicket = async ticket => {
   const ss = new ScreenshotManager(defaultUserAgent);
   const ssArtifacts = await ss.processScreenshots(ticket, page);
   const ocr = new OCRManager();
-  const ocrArtifacts = await ocr.processImages('eng', ssArtifacts);
+  const ocrArtifacts = await ocr.processImages('eng', ssArtifacts.data);
   artifacts.push(...ssArtifacts);
   artifacts.push(...ocrArtifacts);
 

--- a/src/utils/tickets.js
+++ b/src/utils/tickets.js
@@ -80,6 +80,7 @@ const processTicket = async ticket => {
   // process screenshots
   const defaultUserAgent = await browser.userAgent();
   const ss = new ScreenshotManager(defaultUserAgent);
+  const ocrManager = new OCRManager();
   const ssArtifacts = await ss.processScreenshots(ticket, page);
   const ocrArtifacts = await ocrManager.processImages(ssArtifacts);
 

--- a/src/utils/tickets.js
+++ b/src/utils/tickets.js
@@ -53,6 +53,7 @@ const getMalwareMatches = async URLs => {
       return [];
     });
 };
+import OCRManager from '../manager/OCRManager.js';
 
 const processTicket = async ticket => {
   const ticketId = ticket.getID();
@@ -80,7 +81,10 @@ const processTicket = async ticket => {
   const defaultUserAgent = await browser.userAgent();
   const ss = new ScreenshotManager(defaultUserAgent);
   const ssArtifacts = await ss.processScreenshots(ticket, page);
+  const ocr = new OCRManager();
+  const ocrArtifacts = await ocr.processImages('eng', ssArtifacts);
   artifacts.push(...ssArtifacts);
+  artifacts.push(...ocrArtifacts);
 
   // process resources
   const jsArtifacts = await resourceManager.process();


### PR DESCRIPTION
Uses tesseract to perform OCR on screenshots taken of the target website. Resolves #22, #44.

# Testing
Please run `brew install tesseract` on macOS to set up the tesseract native dependency.

# Performance
Takes a max of about 2 seconds to run on the full page screenshot of target.com on a slow machine (i7-4790, pretty thermally throttled), or about 0.3 seconds on a fast machine (3950x, WSL, not throttled). Previously tested with a non-native tesseract dependency based on emscripten ([tesseract.js](https://tesseract.projectnaptha.com)), takes about 400 seconds on the slow machine (not acceptable).

Runs on all screenshots in parallel. Uses the tesseract languages the user has set up on their system, but currently forces english for recognition. Using a less popular wrapper around `libtesseract` so we can pass in the screenshot data as a buffer without writing to disk.

Black text on a white background works fairly well, but animating, heavily styled or text on a distracting background can give less accurate results. The user could install more training data to fix this, at the cost of a longer runtime.

# Output
Adds a new file artifact type. For each screenshot that had recognizable text, a .ocr file will be created to store it. For example, with target.com and the default screenshotFull:
<img width="748" alt="image" src="https://user-images.githubusercontent.com/1558223/75616682-ee630c00-5b19-11ea-965e-a11cb644b6eb.png">


# Dependencies
Will require a new component type to display the OCR results on the frontend, currently being tracked in [frontend/#78](https://github.com/csci4950tgt/frontend/issues/78).
