### PR TITLE
feat(OCR): per-image collection and analysis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,6 +143,11 @@
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -254,6 +259,11 @@
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
       "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
       "dev": true
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
     },
     "cer": {
       "version": "1.0.0",
@@ -747,6 +757,16 @@
       "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
+    "http-basic": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
+      "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
+      "requires": {
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.6",
+        "http-response-object": "^1.0.0"
+      }
+    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -758,6 +778,11 @@
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       }
+    },
+    "http-response-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
+      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
     },
     "https-proxy-agent": {
       "version": "2.2.4",
@@ -821,6 +846,11 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
+    },
+    "image-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/image-extensions/-/image-extensions-1.1.0.tgz",
+      "integrity": "sha1-uOa/YDnfAFbjM1AqALZjejEF2JQ="
     },
     "import-fresh": {
       "version": "2.0.0",
@@ -928,6 +958,24 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-image": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-image/-/is-image-1.0.1.tgz",
+      "integrity": "sha1-b9UadSoaERUG0GDZUhGLC5ibQm4=",
+      "requires": {
+        "image-extensions": "^1.0.1"
+      }
+    },
+    "is-image-url": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/is-image-url/-/is-image-url-1.1.8.tgz",
+      "integrity": "sha1-qmK/l1fFvlQCJpmcdMOiGtqYuDw=",
+      "requires": {
+        "is-image": "^1.0.1",
+        "is-url": "^1.2.1",
+        "sync-request": "^2.1.0"
+      }
+    },
     "is-installed-globally": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
@@ -982,6 +1030,11 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -1285,6 +1338,11 @@
       "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
       "dev": true
     },
+    "os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -1536,6 +1594,14 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
     },
     "proxy-addr": {
       "version": "2.0.6",
@@ -1852,6 +1918,15 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+      "requires": {
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
+      }
+    },
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -1949,6 +2024,17 @@
         "has-flag": "^3.0.0"
       }
     },
+    "sync-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-2.2.0.tgz",
+      "integrity": "sha1-p70sES+glGPrkUnP8OnUKMR5do8=",
+      "requires": {
+        "concat-stream": "^1.4.7",
+        "http-response-object": "^1.0.1",
+        "spawn-sync": "^1.0.1",
+        "then-request": "^2.0.1"
+      }
+    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -2001,6 +2087,19 @@
         "destroy": "^1.0.4",
         "once": "^1.4.0",
         "which": "^1.3.1"
+      }
+    },
+    "then-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
+      "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
+      "requires": {
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.7",
+        "http-basic": "^2.5.1",
+        "http-response-object": "^1.1.0",
+        "promise": "^7.1.1",
+        "qs": "^6.1.0"
       }
     },
     "timed-out": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@limedocs/express-middleware-memfs": "^1.0.0-beta.18",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "is-image-url": "^1.1.8",
     "memfs": "^3.0.4",
     "node-fetch": "^2.6.0",
     "puppeteer": "^1.20.0",

--- a/src/manager/AsyncWorker.js
+++ b/src/manager/AsyncWorker.js
@@ -6,7 +6,7 @@ class ReadyEmitter extends EventEmitter {}
 export default class AsyncWorker {
   constructor(operation) {
     this.operation = operation;
-    this.ready = false;
+    this.isReady = false;
     this.readyEmitter = new ReadyEmitter();
     this.wallClock = Date.now();
   }
@@ -18,14 +18,17 @@ export default class AsyncWorker {
   }
 
   finish() {
+    if (this.wallClock === -1) return;
+
     const delta = Date.now() - this.wallClock;
 
     console.log(`Operation ${this.operation} completed in ${delta}ms.`);
+    this.wallClock = -1;
   }
 
   waitUntilReady() {
     return new Promise(resolve => {
-      if (this.ready) {
+      if (this.isReady) {
         resolve(true);
       } else {
         this.readyEmitter.on('ready', resolve);
@@ -34,7 +37,9 @@ export default class AsyncWorker {
   }
 
   ready() {
-    this.ready = true;
-    this.readyEmitter.emit('ready');
+    if (!this.isReady) {
+      this.isReady = true;
+      this.readyEmitter.emit('ready');
+    }
   }
 }

--- a/src/manager/AsyncWorker.js
+++ b/src/manager/AsyncWorker.js
@@ -18,12 +18,11 @@ export default class AsyncWorker {
   }
 
   finish() {
-    if (this.wallClock === -1) return;
+    if (!this.isReady) return;
 
     const delta = Date.now() - this.wallClock;
 
     console.log(`Operation ${this.operation} completed in ${delta}ms.`);
-    this.wallClock = -1;
   }
 
   waitUntilReady() {

--- a/src/utils/tickets.js
+++ b/src/utils/tickets.js
@@ -73,7 +73,7 @@ const processTicket = async ticket => {
   return {
     success: true,
     fileArtifacts: artifacts.map(ArtifactManager.artifactToPath),
-    malwareMatches: JSON.stringify(asyncArtifacts[2]),
+    malwareMatches: JSON.stringify(asyncArtifacts[3]),
   };
 };
 

--- a/src/utils/tickets.js
+++ b/src/utils/tickets.js
@@ -5,6 +5,7 @@ import ArtifactManager from '../manager/ArtifactManager.js';
 import YaraManager from '../manager/YaraManager.js';
 import OCRManager from '../manager/OCRManager.js';
 import SafeBrowsingManager from '../manager/SafeBrowsingManager.js';
+import isImageUrl from 'is-image-url';
 
 const processTicket = async ticket => {
   const ticketId = ticket.getID();
@@ -30,11 +31,21 @@ const processTicket = async ticket => {
   const artifacts = [];
 
   // process resources, waits for page to finish loading
-  const jsArtifacts = await resourceManager.process();
-  artifacts.push(...jsArtifacts);
+  const resourceArtifacts = await resourceManager.process();
+  artifacts.push(...resourceArtifacts);
 
   // needed for safe browsing:
   const urls = resourceManager.getURLs();
+
+  // filter out only js files for yara:
+  const jsArtifacts = resourceArtifacts.filter(
+    artifact => !isImageUrl(artifact.filename)
+  );
+
+  // filter out images for OCR:
+  const imgArtifacts = resourceArtifacts.filter(artifact =>
+    isImageUrl(artifact.filename)
+  );
 
   // process screenshots. ocr depends on this, so doing in sync...
   const ssArtifacts = await ssManager.processScreenshots(ticket, page);
@@ -42,7 +53,7 @@ const processTicket = async ticket => {
   // do next 3 tasks in parallel using Promise.all.
   // ocr, yara, safe browsing API
   const asyncArtifacts = await Promise.all([
-    ocrManager.processImages(ssArtifacts),
+    ocrManager.processImages(imgArtifacts),
     yaraManager.setupResourceScan(jsArtifacts, ticket),
     safeBrowsingManager.getMalwareMatches(urls),
   ]);


### PR DESCRIPTION
**Changes**
- Watches for any image-type files to be requested by the page.
- Stores them, and and passes them off to tesseract for OCR.

**Other**
- Screenshots now happen in parallel with everything else, since OCR doesn't need the output.
- Done/ready state for the page is now tracked based off the last time a relevant (image or js) file gets requested - one second since the last time that took place, to give the page time to fully load.
- The js `load` event from the page also count towards this, although I found that it usually fires early, thus the one-second rule.
- If a page is still making requests for relevant resources after ten seconds, it gets marked complete anyways.

**Dependencies**
- This will need the frontend to showcase the images and OCR results from the page as a separate component. Per last meeting, @alejx is taking this.

Closes #48.