### PR TITLE
refactor(filenaming): Allows filtering by '.yara' on the frontend

### DIFF
--- a/src/manager/YaraManager.js
+++ b/src/manager/YaraManager.js
@@ -51,7 +51,7 @@ export default class YaraManager extends AsyncWorker {
     super.start();
 
     const ticketId = ticket.getID();
-    const responseFile = 'yara_response.txt';
+    const responseFile = 'yara_response.yara';
     const initialize = promisify(yara.initialize);
 
     try {
@@ -92,7 +92,7 @@ export default class YaraManager extends AsyncWorker {
               this.resources.push(
                 this.createYaraArtifact(
                   ticketId,
-                  js.filename,
+                  js.filename + '.yara',
                   false,
                   true,
                   matchText
@@ -103,7 +103,10 @@ export default class YaraManager extends AsyncWorker {
             console.log(error);
 
             this.resources.push(
-              this.createYaraArtifact(ticketId, js.filename, true)
+              this.createYaraArtifact(
+                ticketId, 
+                js.filename + '.yara', 
+                true)
             );
           }
         }

--- a/src/manager/YaraManager.js
+++ b/src/manager/YaraManager.js
@@ -51,7 +51,7 @@ export default class YaraManager extends AsyncWorker {
     super.start();
 
     const ticketId = ticket.getID();
-    const responseFile = 'yara_response.yara';
+    const responseFile = 'response.yara';
     const initialize = promisify(yara.initialize);
 
     try {


### PR DESCRIPTION
Previously had .txt or .js file extension, now .txt->.yara, .js->.js.yara (not sure if a substr is necessary here... thoughts?)