### PR TITLE
hotfix(ResourceManager): copy image buffer, sometimes puppeteer frees…

### DIFF
--- a/src/manager/ResourceManager.js
+++ b/src/manager/ResourceManager.js
@@ -100,7 +100,7 @@ export default class ResourceManager extends AsyncWorker {
         this.resources.push({
           ticketId,
           filename: identifier,
-          data: buf,
+          data: Buffer.from(buf),
         });
       }
     });


### PR DESCRIPTION
If you got unlucky, puppeteer would free the memory that stores the images before the OCR could process it. Now we manually copy the buffer to make sure this doesn't happen.