### PR TITLE
hotfix(ocr): if tesseract fails on an image, skip it

### DIFF
--- a/src/manager/OCRManager.js
+++ b/src/manager/OCRManager.js
@@ -12,7 +12,13 @@ export default class OCRManager extends AsyncWorker {
   async getTextFromImage(screenshot) {
     console.log(`Start recognition process for ${screenshot.filename}.`);
 
-    const res = await recognize(screenshot.data, { language: this.lang });
+    let res;
+
+    try {
+      res = await recognize(screenshot.data, { language: this.lang });
+    } catch (e) {
+      return null;
+    }
 
     console.log(`Recognized the following text in image: ${res}`);
 

--- a/src/utils/tickets.js
+++ b/src/utils/tickets.js
@@ -57,7 +57,7 @@ const processTicket = async ticket => {
   ]);
 
   artifacts.push(...asyncArtifacts[0]); // screenshots
-  artifacts.push(...asyncArtifacts[1]); // ocr
+  artifacts.push(...asyncArtifacts[1].filter(a => a)); // ocr, remove nulls
   artifacts.push(...asyncArtifacts[2]); // yara
 
   // store


### PR DESCRIPTION
- Sometimes tesseract fails to process an image. In the instances I've seen so far, this is because the image is an SVG, and the library tries to load in the `xmlns` URL and fails.
- In any case, a tesseract failure doesn't mean the rest of the images won't work, or the other analysis isn't useful. So, we skip images that fail and continue on.